### PR TITLE
Update docx.py

### DIFF
--- a/sphinx-docxbuilder/docx/docx.py
+++ b/sphinx-docxbuilder/docx/docx.py
@@ -371,7 +371,7 @@ class DocxDocument:
         file_name = join(to_dir,fname)
         if not os.path.exists(os.path.dirname(file_name)) :
           os.makedirs(os.path.dirname(file_name)) 
-        f = open(file_name, 'w')
+        f = open(file_name, 'wb') #Because var xmlcontent type is bytes, so need to openfile with 'wb'
         f.write(xmlcontent)
         f.close()
     except:


### PR DESCRIPTION
Fix error "Error in extract_files ...", cause by statement : f.write(xmlcontent), when trying extract docx file.
Fix by change parameter for open file function to 'wb', because the type of variable 'xmlcontent' is bytes.